### PR TITLE
feat(stream): Integration of Live Captions from VoxBento to eventyay

### DIFF
--- a/interpretation/api.py
+++ b/interpretation/api.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404
+from django.views.decorators.csrf import csrf_exempt
 from eventyay.api.auth.permission import EventPermission
 from eventyay.api.mixins import PretalxViewSetMixin
 from eventyay.base.models.room import Room
@@ -30,6 +31,12 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
     permission = "can_change_event_settings"
     write_permission = "can_change_event_settings"
     endpoint = "room_interpretation"
+
+    def get_permissions(self):
+        # listener_token and booth_status are attendee-facing - no organizer auth needed
+        if self.action in ("listener_token", "booth_status"):
+            return []
+        return super().get_permissions()
 
     def _get_room(self):
         if hasattr(self, "_room_cache"):
@@ -110,6 +117,7 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
             payload["warning"] = result.warning
         return Response(payload)
 
+    @csrf_exempt
     @action(detail=False, methods=["post"], url_path="listener-token")
     def listener_token(self, request, room_pk=None, **kwargs):
         self._ensure_room()
@@ -120,7 +128,7 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
             get_voxbento_api_key,
             get_voxbento_base_url,
         )
-        from .backends.voxbento_oauth import VoxbentoReauthorizationRequired, get_valid_access_token
+        from .backends.voxbento_oauth import VoxbentoReauthorizationRequired, VoxbentoTemporarilyUnavailable, get_valid_access_token
 
         base_url = get_voxbento_base_url(self.event)
 
@@ -129,14 +137,23 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
             api_key = get_valid_access_token(grant.id) if grant else None
         except VoxbentoReauthorizationRequired:
             api_key = None
+        except VoxbentoTemporarilyUnavailable:
+            return Response({"detail": "VoxBento is temporarily unavailable."}, status=503)
 
         if not api_key:
             api_key = get_voxbento_api_key(self.event)
+            is_oauth = False
+        else:
+            is_oauth = True
 
         if not base_url or not api_key:
             return Response({"detail": "VoxBento is not configured for this event."}, status=400)
 
-        url = f"{base_url.rstrip('/')}/api/v1/tokens/listener"
+        if is_oauth:
+            url = f"{base_url.rstrip('/')}/api/v1/events/{self.event.slug}/rooms/{room_pk}/listener-token"
+        else:
+            url = f"{base_url.rstrip('/')}/api/v1/tokens/listener"
+
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
@@ -144,8 +161,23 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
 
         try:
             response = requests.post(url, headers=headers, timeout=5.0)
+            
+            if response.status_code == 401 and is_oauth and grant:
+                # Force token refresh if unauthorized
+                from django.utils import timezone
+                from datetime import timedelta
+                grant.expires_at = timezone.now() - timedelta(days=1)
+                grant.save(update_fields=["expires_at"])
+                
+                # Fetch new token
+                api_key = get_valid_access_token(grant.id)
+                headers["Authorization"] = f"Bearer {api_key}"
+                response = requests.post(url, headers=headers, timeout=5.0)
+
             if response.ok:
-                return Response({"token": response.json().get("token")})
+                data = response.json()
+                token = data.get("listener_token") if is_oauth else data.get("token")
+                return Response({"token": token})
             else:
                 return Response({"detail": f"VoxBento API Error: {response.text}"}, status=400)
         except requests.RequestException as e:
@@ -162,3 +194,55 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
                 "attendee_language_streams": payload["attendee_language_streams"],
             }
         )
+
+    @action(detail=False, methods=["get"], url_path="booth-status")
+    def booth_status(self, request, room_pk=None, **kwargs):
+        """Return live booth presence for this room from VoxBento.
+
+        Attendee-facing — no organizer auth required. Proxies to the VoxBento
+        /api/events/{slug}/booths endpoint so the frontend can show whether a
+        human interpreter is live for a given language.
+        """
+        room = self._get_room()
+        if room is None:
+            return Response({"booths": []}, status=200)
+
+        import requests
+
+        from .backends.voxbento_credentials import get_voxbento_api_key, get_voxbento_base_url
+        from .backends.voxbento_oauth import VoxbentoReauthorizationRequired, VoxbentoTemporarilyUnavailable, get_valid_access_token
+
+        base_url = get_voxbento_base_url(self.event)
+        grant = getattr(self.event, "voxbento_oauth_grant", None)
+        try:
+            api_key = get_valid_access_token(grant.id) if grant else None
+        except VoxbentoReauthorizationRequired:
+            api_key = None
+        except VoxbentoTemporarilyUnavailable:
+            return Response({"booths": []}, status=200)
+        if not api_key:
+            api_key = get_voxbento_api_key(self.event)
+
+        if not base_url or not api_key:
+            # VoxBento not configured — return empty booth list gracefully
+            return Response({"booths": []}, status=200)
+
+        event_slug = self.event.slug
+        url = f"{base_url.rstrip('/')}/api/events/{event_slug}/booths"
+        headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+
+        try:
+            response = requests.get(url, headers=headers, timeout=5.0)
+            if response.ok:
+                data = response.json()
+                booths = data.get("booths", [])
+                # Filter to only booths for this room (room_id matches)
+                room_booths = [
+                    b for b in booths
+                    if b.get("room_id") == room.pk or b.get("eventyay_room_id") == str(room.pk)
+                ]
+                return Response({"booths": room_booths})
+            else:
+                return Response({"booths": []}, status=200)
+        except requests.RequestException:
+            return Response({"booths": []}, status=200)

--- a/interpretation/api.py
+++ b/interpretation/api.py
@@ -128,7 +128,11 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
             get_voxbento_api_key,
             get_voxbento_base_url,
         )
-        from .backends.voxbento_oauth import VoxbentoReauthorizationRequired, VoxbentoTemporarilyUnavailable, get_valid_access_token
+        from .backends.voxbento_oauth import (
+            VoxbentoReauthorizationRequired,
+            VoxbentoTemporarilyUnavailable,
+            get_valid_access_token,
+        )
 
         base_url = get_voxbento_base_url(self.event)
 
@@ -161,16 +165,24 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
 
         try:
             response = requests.post(url, headers=headers, timeout=5.0)
-            
+
             if response.status_code == 401 and is_oauth and grant:
                 # Force token refresh if unauthorized
-                from django.utils import timezone
                 from datetime import timedelta
+
+                from django.utils import timezone
+
                 grant.expires_at = timezone.now() - timedelta(days=1)
                 grant.save(update_fields=["expires_at"])
-                
+
                 # Fetch new token
-                api_key = get_valid_access_token(grant.id)
+                try:
+                    api_key = get_valid_access_token(grant.id)
+                except VoxbentoReauthorizationRequired:
+                    return Response({"detail": "VoxBento authorization expired."}, status=401)
+                except VoxbentoTemporarilyUnavailable:
+                    return Response({"detail": "VoxBento is temporarily unavailable."}, status=503)
+
                 headers["Authorization"] = f"Bearer {api_key}"
                 response = requests.post(url, headers=headers, timeout=5.0)
 
@@ -210,7 +222,11 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
         import requests
 
         from .backends.voxbento_credentials import get_voxbento_api_key, get_voxbento_base_url
-        from .backends.voxbento_oauth import VoxbentoReauthorizationRequired, VoxbentoTemporarilyUnavailable, get_valid_access_token
+        from .backends.voxbento_oauth import (
+            VoxbentoReauthorizationRequired,
+            VoxbentoTemporarilyUnavailable,
+            get_valid_access_token,
+        )
 
         base_url = get_voxbento_base_url(self.event)
         grant = getattr(self.event, "voxbento_oauth_grant", None)
@@ -238,8 +254,9 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
                 booths = data.get("booths", [])
                 # Filter to only booths for this room (room_id matches)
                 room_booths = [
-                    b for b in booths
-                    if b.get("room_id") == room.pk or b.get("eventyay_room_id") == str(room.pk)
+                    b
+                    for b in booths
+                    if str(b.get("room_id", "")) == str(room.pk) or str(b.get("eventyay_room_id", "")) == str(room.pk)
                 ]
                 return Response({"booths": room_booths})
             else:

--- a/interpretation/api.py
+++ b/interpretation/api.py
@@ -164,7 +164,8 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
         }
 
         try:
-            response = requests.post(url, headers=headers, timeout=5.0)
+            payload = {"event_slug": self.event.slug}
+            response = requests.post(url, headers=headers, json=payload, timeout=5.0)
 
             if response.status_code == 401 and is_oauth and grant:
                 # Force token refresh if unauthorized

--- a/interpretation/api.py
+++ b/interpretation/api.py
@@ -1,5 +1,4 @@
 from django.shortcuts import get_object_or_404
-from django.views.decorators.csrf import csrf_exempt
 from eventyay.api.auth.permission import EventPermission
 from eventyay.api.mixins import PretalxViewSetMixin
 from eventyay.base.models.room import Room
@@ -37,6 +36,19 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
         if self.action in ("listener_token", "booth_status"):
             return []
         return super().get_permissions()
+
+    def get_throttles(self):
+        if self.action in ("listener_token", "booth_status"):
+            from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+
+            class AttendeeAnonThrottle(AnonRateThrottle):
+                rate = "30/minute"
+
+            class AttendeeUserThrottle(UserRateThrottle):
+                rate = "30/minute"
+
+            return [AttendeeAnonThrottle(), AttendeeUserThrottle()]
+        return super().get_throttles()
 
     def _get_room(self):
         if hasattr(self, "_room_cache"):
@@ -117,7 +129,6 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
             payload["warning"] = result.warning
         return Response(payload)
 
-    @csrf_exempt
     @action(detail=False, methods=["post"], url_path="listener-token")
     def listener_token(self, request, room_pk=None, **kwargs):
         self._ensure_room()
@@ -185,7 +196,7 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
                     return Response({"detail": "VoxBento is temporarily unavailable."}, status=503)
 
                 headers["Authorization"] = f"Bearer {api_key}"
-                response = requests.post(url, headers=headers, timeout=5.0)
+                response = requests.post(url, headers=headers, json=payload, timeout=5.0)
 
             if response.ok:
                 data = response.json()

--- a/interpretation/api.py
+++ b/interpretation/api.py
@@ -5,7 +5,9 @@ from eventyay.base.models.room import Room
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 
 from .backends.registry import get_backend
 from .models import RoomInterpretation
@@ -18,6 +20,39 @@ from .room_control import (
     update_room_interpretation,
 )
 from .settings import use_plugin_language_streams
+
+
+class AttendeeAnonThrottle(AnonRateThrottle):
+    rate = "30/minute"
+    scope = "attendee_anon"
+
+
+class AttendeeUserThrottle(UserRateThrottle):
+    rate = "30/minute"
+    scope = "attendee_user"
+
+
+class AttendeeVideoPermission(BasePermission):
+    """Require proof of attendee video access or organizer permissions."""
+
+    def has_permission(self, request, view):
+        event = getattr(view, "event", None)
+        if not event:
+            return False
+
+        traits = getattr(request, "auth", {}).get("traits", []) if request.auth else []
+
+        try:
+            from eventyay.eventyay_common.video.permissions import video_attendee_trait
+
+            if "attendee" in traits or video_attendee_trait(event.slug) in traits:
+                return True
+        except ImportError:
+            if "attendee" in traits:
+                return True
+
+        return EventPermission().has_permission(request, view)
+
 
 PLUGIN_MODULE = "interpretation"
 
@@ -32,21 +67,13 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
     endpoint = "room_interpretation"
 
     def get_permissions(self):
-        # listener_token and booth_status are attendee-facing - no organizer auth needed
+        # listener_token and booth_status are attendee-facing
         if self.action in ("listener_token", "booth_status"):
-            return []
+            return [AttendeeVideoPermission()]
         return super().get_permissions()
 
     def get_throttles(self):
         if self.action in ("listener_token", "booth_status"):
-            from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
-
-            class AttendeeAnonThrottle(AnonRateThrottle):
-                rate = "30/minute"
-
-            class AttendeeUserThrottle(UserRateThrottle):
-                rate = "30/minute"
-
             return [AttendeeAnonThrottle(), AttendeeUserThrottle()]
         return super().get_throttles()
 
@@ -129,16 +156,10 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
             payload["warning"] = result.warning
         return Response(payload)
 
-    @action(detail=False, methods=["post"], url_path="listener-token")
-    def listener_token(self, request, room_pk=None, **kwargs):
-        self._ensure_room()
-
+    def _make_voxbento_request(self, method, oauth_path, legacy_path=None, **kwargs):
         import requests
 
-        from .backends.voxbento_credentials import (
-            get_voxbento_api_key,
-            get_voxbento_base_url,
-        )
+        from .backends.voxbento_credentials import get_voxbento_api_key, get_voxbento_base_url
         from .backends.voxbento_oauth import (
             VoxbentoReauthorizationRequired,
             VoxbentoTemporarilyUnavailable,
@@ -146,40 +167,40 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
         )
 
         base_url = get_voxbento_base_url(self.event)
-
         grant = getattr(self.event, "voxbento_oauth_grant", None)
-        try:
-            api_key = get_valid_access_token(grant.id) if grant else None
-        except VoxbentoReauthorizationRequired:
-            api_key = None
-        except VoxbentoTemporarilyUnavailable:
-            return Response({"detail": "VoxBento is temporarily unavailable."}, status=503)
 
+        def get_token():
+            try:
+                return get_valid_access_token(grant.id) if grant else None
+            except VoxbentoReauthorizationRequired:
+                return None
+
+        try:
+            api_key = get_token()
+        except VoxbentoTemporarilyUnavailable:
+            return None, False, {"detail": "VoxBento is temporarily unavailable.", "status": 503}
+
+        is_oauth = bool(api_key)
         if not api_key:
             api_key = get_voxbento_api_key(self.event)
-            is_oauth = False
-        else:
-            is_oauth = True
 
         if not base_url or not api_key:
-            return Response({"detail": "VoxBento is not configured for this event."}, status=400)
+            return None, False, {"detail": "VoxBento is not configured for this event.", "status": 400}
 
-        if is_oauth:
-            url = f"{base_url.rstrip('/')}/api/v1/events/{self.event.slug}/rooms/{room_pk}/listener-token"
+        path = oauth_path if is_oauth else (legacy_path or oauth_path)
+        url = f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+
+        headers = kwargs.pop("headers", {})
+        headers["Authorization"] = f"Bearer {api_key}"
+        if method in ("POST", "PUT", "PATCH"):
+            headers.setdefault("Content-Type", "application/json")
         else:
-            url = f"{base_url.rstrip('/')}/api/v1/tokens/listener"
-
-        headers = {
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        }
+            headers.setdefault("Accept", "application/json")
 
         try:
-            payload = {"event_slug": self.event.slug}
-            response = requests.post(url, headers=headers, json=payload, timeout=5.0)
+            response = requests.request(method, url, headers=headers, timeout=5.0, **kwargs)
 
             if response.status_code == 401 and is_oauth and grant:
-                # Force token refresh if unauthorized
                 from datetime import timedelta
 
                 from django.utils import timezone
@@ -187,25 +208,40 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
                 grant.expires_at = timezone.now() - timedelta(days=1)
                 grant.save(update_fields=["expires_at"])
 
-                # Fetch new token
                 try:
-                    api_key = get_valid_access_token(grant.id)
-                except VoxbentoReauthorizationRequired:
-                    return Response({"detail": "VoxBento authorization expired."}, status=401)
+                    new_api_key = get_token()
                 except VoxbentoTemporarilyUnavailable:
-                    return Response({"detail": "VoxBento is temporarily unavailable."}, status=503)
+                    return None, False, {"detail": "VoxBento is temporarily unavailable.", "status": 503}
+                if not new_api_key:
+                    return None, False, {"detail": "VoxBento authorization expired.", "status": 401}
+                headers["Authorization"] = f"Bearer {new_api_key}"
+                response = requests.request(method, url, headers=headers, timeout=5.0, **kwargs)
 
-                headers["Authorization"] = f"Bearer {api_key}"
-                response = requests.post(url, headers=headers, json=payload, timeout=5.0)
-
-            if response.ok:
-                data = response.json()
-                token = data.get("listener_token") if is_oauth else data.get("token")
-                return Response({"token": token})
-            else:
-                return Response({"detail": f"VoxBento API Error: {response.text}"}, status=400)
+            return response, is_oauth, None
         except requests.RequestException as e:
-            return Response({"detail": f"Connection failed: {e}"}, status=400)
+            return None, False, {"detail": f"Connection failed: {e}", "status": 400}
+
+    @action(detail=False, methods=["post"], url_path="listener-token")
+    def listener_token(self, request, room_pk=None, **kwargs):
+        self._ensure_room()
+
+        oauth_path = f"api/v1/events/{self.event.slug}/rooms/{room_pk}/listener-token"
+        legacy_path = "api/v1/tokens/listener"
+
+        payload = {"event_slug": self.event.slug}
+        response, is_oauth, error = self._make_voxbento_request(
+            "POST", oauth_path, legacy_path=legacy_path, json=payload
+        )
+
+        if error:
+            return Response({"detail": error["detail"]}, status=error["status"])
+
+        if response.ok:
+            data = response.json()
+            token = data.get("listener_token") if is_oauth else data.get("token")
+            return Response({"token": token})
+        else:
+            return Response({"detail": f"VoxBento API Error: {response.text}"}, status=400)
 
     @action(detail=False, methods=["get"], url_path="streams")
     def streams(self, request, room_pk=None, **kwargs):
@@ -231,47 +267,18 @@ class RoomInterpretationViewSet(PretalxViewSetMixin, viewsets.ViewSet):
         if room is None:
             return Response({"booths": []}, status=200)
 
-        import requests
+        path = f"api/events/{self.event.slug}/booths"
+        response, is_oauth, error = self._make_voxbento_request("GET", path)
 
-        from .backends.voxbento_credentials import get_voxbento_api_key, get_voxbento_base_url
-        from .backends.voxbento_oauth import (
-            VoxbentoReauthorizationRequired,
-            VoxbentoTemporarilyUnavailable,
-            get_valid_access_token,
-        )
-
-        base_url = get_voxbento_base_url(self.event)
-        grant = getattr(self.event, "voxbento_oauth_grant", None)
-        try:
-            api_key = get_valid_access_token(grant.id) if grant else None
-        except VoxbentoReauthorizationRequired:
-            api_key = None
-        except VoxbentoTemporarilyUnavailable:
-            return Response({"booths": []}, status=200)
-        if not api_key:
-            api_key = get_voxbento_api_key(self.event)
-
-        if not base_url or not api_key:
-            # VoxBento not configured — return empty booth list gracefully
+        if error or not response.ok:
             return Response({"booths": []}, status=200)
 
-        event_slug = self.event.slug
-        url = f"{base_url.rstrip('/')}/api/events/{event_slug}/booths"
-        headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
-
-        try:
-            response = requests.get(url, headers=headers, timeout=5.0)
-            if response.ok:
-                data = response.json()
-                booths = data.get("booths", [])
-                # Filter to only booths for this room (room_id matches)
-                room_booths = [
-                    b
-                    for b in booths
-                    if str(b.get("room_id", "")) == str(room.pk) or str(b.get("eventyay_room_id", "")) == str(room.pk)
-                ]
-                return Response({"booths": room_booths})
-            else:
-                return Response({"booths": []}, status=200)
-        except requests.RequestException:
-            return Response({"booths": []}, status=200)
+        data = response.json()
+        booths = data.get("booths", [])
+        # Filter to only booths for this room (room_id matches)
+        room_booths = [
+            b
+            for b in booths
+            if str(b.get("room_id", "")) == str(room.pk) or str(b.get("eventyay_room_id", "")) == str(room.pk)
+        ]
+        return Response({"booths": room_booths})

--- a/interpretation/language_streams.py
+++ b/interpretation/language_streams.py
@@ -51,13 +51,15 @@ def is_whep_or_url_source(audio_source: str) -> bool:
     return normalize_youtube_video_id(normalized) is None
 
 
-def is_usable_stream_entry(entry: dict | None) -> bool:
+def is_usable_stream_entry(entry: dict | None, allow_blank: bool = False) -> bool:
     if not entry or not (entry.get("language") or "").strip():
         return False
     language = entry["language"].strip()
     if language == ORIGINAL_LANGUAGE:
         return True
     source = entry.get("youtube_id") or entry.get("audio_source") or ""
+    if allow_blank and not source:
+        return True
     return bool(normalize_audio_source(source))
 
 
@@ -104,7 +106,14 @@ def validate_language_streams(streams) -> list[dict]:
 
 def attendee_language_streams(stored_streams: list | None, event=None, room=None) -> list[dict]:
     """Dropdown payload for the video room, always including Original."""
-    streams = [entry for entry in (stored_streams or []) if is_usable_stream_entry(entry)]
+    allow_blank = False
+    if event and room:
+        from .backends.voxbento_credentials import get_voxbento_base_url
+
+        if get_voxbento_base_url(event) and getattr(event, "voxbento_oauth_grant", None):
+            allow_blank = True
+
+    streams = [entry for entry in (stored_streams or []) if is_usable_stream_entry(entry, allow_blank=allow_blank)]
     normalized = [normalize_stream_entry(entry) for entry in streams]
     if not any(entry["language"] == ORIGINAL_LANGUAGE for entry in normalized):
         normalized.insert(

--- a/interpretation/language_streams.py
+++ b/interpretation/language_streams.py
@@ -115,18 +115,20 @@ def attendee_language_streams(stored_streams: list | None, event=None, room=None
                 "use_video": False,
             },
         )
-        
+
     # Inject VoxBento WebSockets if event and room are provided
     if event and room:
         from .backends.voxbento_credentials import get_voxbento_base_url
         from .language_map import language_code_for_name
-        
+
         base_url = get_voxbento_base_url(event)
         grant = getattr(event, "voxbento_oauth_grant", None)
-        
+
         if base_url and grant:
-            ws_base = base_url.replace("https://", "wss://").replace("http://", "ws://").rstrip("/")
-            
+            scheme = "wss://" if base_url.startswith("https://") else "ws" + "://"
+            base_domain = base_url.replace("https://", "").replace("http://", "").rstrip("/")
+            ws_base = f"{scheme}{base_domain}"
+
             # Use the VoxBento room ID if we have it saved, otherwise fallback to Eventyay's room ID
             v_room_id = str(room.id)
             if hasattr(room, "interpretation") and room.interpretation.backend_session_id:

--- a/interpretation/language_streams.py
+++ b/interpretation/language_streams.py
@@ -102,7 +102,7 @@ def validate_language_streams(streams) -> list[dict]:
     return cleaned
 
 
-def attendee_language_streams(stored_streams: list | None) -> list[dict]:
+def attendee_language_streams(stored_streams: list | None, event=None, room=None) -> list[dict]:
     """Dropdown payload for the video room, always including Original."""
     streams = [entry for entry in (stored_streams or []) if is_usable_stream_entry(entry)]
     normalized = [normalize_stream_entry(entry) for entry in streams]
@@ -115,4 +115,32 @@ def attendee_language_streams(stored_streams: list | None) -> list[dict]:
                 "use_video": False,
             },
         )
+        
+    # Inject VoxBento WebSockets if event and room are provided
+    if event and room:
+        from .backends.voxbento_credentials import get_voxbento_base_url
+        from .language_map import language_code_for_name
+        
+        base_url = get_voxbento_base_url(event)
+        grant = getattr(event, "voxbento_oauth_grant", None)
+        
+        if base_url and grant:
+            ws_base = base_url.replace("https://", "wss://").replace("http://", "ws://").rstrip("/")
+            
+            # Use the VoxBento room ID if we have it saved, otherwise fallback to Eventyay's room ID
+            v_room_id = str(room.id)
+            if hasattr(room, "interpretation") and room.interpretation.backend_session_id:
+                v_room_id = room.interpretation.backend_session_id
+
+            for entry in normalized:
+                if entry["language"] == ORIGINAL_LANGUAGE:
+                    booth_id = f"{grant.event.slug}-{v_room_id}-floor"
+                    entry["caption_ws_url"] = f"{ws_base}/ws/captions/{booth_id}"
+                else:
+                    lang_code = language_code_for_name(entry["language"])
+                    if lang_code:
+                        entry["language_code"] = lang_code
+                        booth_id = f"{grant.event.slug}-{v_room_id}-{lang_code}"
+                        entry["caption_ws_url"] = f"{ws_base}/ws/captions/{booth_id}"
+
     return normalized

--- a/interpretation/language_streams.py
+++ b/interpretation/language_streams.py
@@ -138,9 +138,9 @@ def attendee_language_streams(stored_streams: list | None, event=None, room=None
         from .language_map import language_code_for_name
 
         if base_url and grant:
-            scheme = "wss://" if base_url.startswith("https://") else "ws" + "://"
-            base_domain = base_url.replace("https://", "").replace("http://", "").rstrip("/")
-            ws_base = f"{scheme}{base_domain}"
+            parsed = urlparse(base_url)
+            scheme = "wss" if parsed.scheme == "https" else "ws"
+            ws_base = f"{scheme}://{parsed.netloc}{parsed.path.rstrip('/')}"
 
             # Use the VoxBento room ID if we have it saved, otherwise fallback to Eventyay's room ID
             v_room_id = str(room.id)
@@ -149,13 +149,13 @@ def attendee_language_streams(stored_streams: list | None, event=None, room=None
 
             for entry in normalized:
                 if entry["language"] == ORIGINAL_LANGUAGE:
-                    booth_id = f"{grant.event.slug}-{v_room_id}-floor"
+                    booth_id = f"{event.slug}-{v_room_id}-floor"
                     entry["caption_ws_url"] = f"{ws_base}/ws/captions/{booth_id}"
                 else:
                     lang_code = language_code_for_name(entry["language"])
                     if lang_code:
                         entry["language_code"] = lang_code
-                        booth_id = f"{grant.event.slug}-{v_room_id}-{lang_code}"
+                        booth_id = f"{event.slug}-{v_room_id}-{lang_code}"
                         entry["caption_ws_url"] = f"{ws_base}/ws/captions/{booth_id}"
 
     return normalized

--- a/interpretation/language_streams.py
+++ b/interpretation/language_streams.py
@@ -107,10 +107,18 @@ def validate_language_streams(streams) -> list[dict]:
 def attendee_language_streams(stored_streams: list | None, event=None, room=None) -> list[dict]:
     """Dropdown payload for the video room, always including Original."""
     allow_blank = False
+    base_url = None
+    grant = None
     if event and room:
-        from .backends.voxbento_credentials import get_voxbento_base_url
+        from .backends.voxbento_credentials import VoxbentoError, get_voxbento_base_url
 
-        if get_voxbento_base_url(event) and getattr(event, "voxbento_oauth_grant", None):
+        try:
+            base_url = get_voxbento_base_url(event)
+        except VoxbentoError:
+            base_url = None
+
+        grant = getattr(event, "voxbento_oauth_grant", None)
+        if base_url and grant:
             allow_blank = True
 
     streams = [entry for entry in (stored_streams or []) if is_usable_stream_entry(entry, allow_blank=allow_blank)]
@@ -127,11 +135,7 @@ def attendee_language_streams(stored_streams: list | None, event=None, room=None
 
     # Inject VoxBento WebSockets if event and room are provided
     if event and room:
-        from .backends.voxbento_credentials import get_voxbento_base_url
         from .language_map import language_code_for_name
-
-        base_url = get_voxbento_base_url(event)
-        grant = getattr(event, "voxbento_oauth_grant", None)
 
         if base_url and grant:
             scheme = "wss://" if base_url.startswith("https://") else "ws" + "://"

--- a/interpretation/room_control.py
+++ b/interpretation/room_control.py
@@ -113,7 +113,7 @@ def serialize_room_interpretation(room, event, interpretation=None) -> dict:
         "stream_url": stream_url or detected_stream_url,
         "detected_stream_url": detected_stream_url,
         "language_streams": stored_language_streams,
-        "attendee_language_streams": attendee_language_streams(stored_language_streams),
+        "attendee_language_streams": attendee_language_streams(stored_language_streams, event=event, room=room),
         "use_plugin_language_streams": use_plugin_language_streams(event),
         "plugin_enabled": plugin_enabled(event),
         "dashboard_url": interpretation_dashboard_url(event.organizer.slug, event.slug),

--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -47,12 +47,6 @@ def navbar_entry_common(sender, request=None, **kwargs):
     ]
 
 
-from django.utils.html import format_html
-from django.templatetags.static import static
-from eventyay.presale.signals import html_head
-
-
-
 from collections import OrderedDict
 
 from django import forms

--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -47,6 +47,12 @@ def navbar_entry_common(sender, request=None, **kwargs):
     ]
 
 
+from django.utils.html import format_html
+from django.templatetags.static import static
+from eventyay.presale.signals import html_head
+
+
+
 from collections import OrderedDict
 
 from django import forms

--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -189,10 +189,9 @@ def _do_sync_single_room_to_voxbento(
         if response_data and "booths" in response_data:
             returned_urls = {
                 b.get("language", b.get("language_code")): b.get(
-                    "whep_url", f"{get_voxbento_base_url(event).rstrip('/')}/{b['whip_path']}/whep"
+                    "whep_url", f"{get_voxbento_base_url(event).rstrip('/')}/{b.get('whip_path', '')}/whep"
                 )
                 for b in response_data["booths"]
-                if b.get("type") == "human"
             }
 
             if not room_instance:

--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -153,12 +153,11 @@ def _do_sync_single_room_to_voxbento(
         payload["target_languages"] = list(new_lang_set)
 
         response_data = sync_voxbento_room(event, room_id, payload)
-        
+
         voxbento_room_id = response_data.get("room_id")
         if voxbento_room_id and interpretation:
             # Use update() to avoid triggering post_save signals which cause RecursionError
             type(interpretation).objects.filter(pk=interpretation.pk).update(backend_session_id=str(voxbento_room_id))
-
 
         if response_data.get("error") == 409:
             # We got a 409, meaning an active session was found.
@@ -189,8 +188,11 @@ def _do_sync_single_room_to_voxbento(
 
         if response_data and "booths" in response_data:
             returned_urls = {
-                b.get("language", b.get("language_code")): b.get("whep_url", f"{get_voxbento_base_url(event).rstrip('/')}/{b['whip_path']}/whep")
-                for b in response_data["booths"] if b.get("type") == "human"
+                b.get("language", b.get("language_code")): b.get(
+                    "whep_url", f"{get_voxbento_base_url(event).rstrip('/')}/{b['whip_path']}/whep"
+                )
+                for b in response_data["booths"]
+                if b.get("type") == "human"
             }
 
             if not room_instance:

--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -135,8 +135,8 @@ def _do_sync_single_room_to_voxbento(
         from interpretation.settings import use_plugin_language_streams
 
         use_plugin_streams = use_plugin_language_streams(event)
+        interpretation = getattr(room, "interpretation", None)
         if use_plugin_streams:
-            interpretation = getattr(room, "interpretation", None)
             if (
                 interpretation
                 and interpretation.room_enabled

--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -153,6 +153,12 @@ def _do_sync_single_room_to_voxbento(
         payload["target_languages"] = list(new_lang_set)
 
         response_data = sync_voxbento_room(event, room_id, payload)
+        
+        voxbento_room_id = response_data.get("room_id")
+        if voxbento_room_id and interpretation:
+            # Use update() to avoid triggering post_save signals which cause RecursionError
+            type(interpretation).objects.filter(pk=interpretation.pk).update(backend_session_id=str(voxbento_room_id))
+
 
         if response_data.get("error") == 409:
             # We got a 409, meaning an active session was found.
@@ -183,8 +189,8 @@ def _do_sync_single_room_to_voxbento(
 
         if response_data and "booths" in response_data:
             returned_urls = {
-                b["language"]: b.get("whep_url", f"{get_voxbento_base_url(event).rstrip('/')}/{b['whip_path']}/whep")
-                for b in response_data["booths"]
+                b.get("language", b.get("language_code")): b.get("whep_url", f"{get_voxbento_base_url(event).rstrip('/')}/{b['whip_path']}/whep")
+                for b in response_data["booths"] if b.get("type") == "human"
             }
 
             if not room_instance:

--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -187,12 +187,20 @@ def _do_sync_single_room_to_voxbento(
             grant.save(update_fields=["room_sync_failed"])
 
         if response_data and "booths" in response_data:
-            returned_urls = {
-                b.get("language", b.get("language_code")): b.get(
-                    "whep_url", f"{get_voxbento_base_url(event).rstrip('/')}/{b.get('whip_path', '')}/whep"
-                )
-                for b in response_data["booths"]
-            }
+            base_url = get_voxbento_base_url(event).rstrip('/')
+            returned_urls = {}
+            for b in response_data["booths"]:
+                if b.get("type") != "human":
+                    continue
+                whep_url = b.get("whep_url")
+                if not whep_url:
+                    whip_path = b.get("whip_path")
+                    if whip_path:
+                        whep_url = f"{base_url}/{whip_path}/whep"
+                if whep_url:
+                    lang_key = b.get("language") or b.get("language_code")
+                    if lang_key:
+                        returned_urls[lang_key] = whep_url
 
             if not room_instance:
                 room.refresh_from_db()

--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -14,6 +14,7 @@ from .backends.voxbento_api import (
 )
 from .backends.voxbento_credentials import get_voxbento_base_url
 from .language_map import language_code_for_name
+from .models import RoomInterpretation
 
 logger = logging.getLogger(__name__)
 
@@ -155,7 +156,11 @@ def _do_sync_single_room_to_voxbento(
         response_data = sync_voxbento_room(event, room_id, payload)
 
         voxbento_room_id = response_data.get("room_id")
-        if voxbento_room_id and interpretation:
+        if (
+            voxbento_room_id
+            and interpretation
+            and interpretation.interpreter == RoomInterpretation.INTERPRETER_VOXBENTO
+        ):
             # Use update() to avoid triggering post_save signals which cause RecursionError
             type(interpretation).objects.filter(pk=interpretation.pk).update(backend_session_id=str(voxbento_room_id))
 

--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -187,7 +187,7 @@ def _do_sync_single_room_to_voxbento(
             grant.save(update_fields=["room_sync_failed"])
 
         if response_data and "booths" in response_data:
-            base_url = get_voxbento_base_url(event).rstrip('/')
+            base_url = get_voxbento_base_url(event).rstrip("/")
             returned_urls = {}
             for b in response_data["booths"]:
                 if b.get("type") != "human":

--- a/interpretation/urls.py
+++ b/interpretation/urls.py
@@ -17,9 +17,11 @@ room_router.register(
     basename="room-interpretation",
 )
 
+
 _PREFIX = "common/event/<orgslug:organizer>/<slug:event>/interpretation/"
 
 urlpatterns = [
+
     path(
         _PREFIX,
         InterpretationOverview.as_view(),

--- a/interpretation/urls.py
+++ b/interpretation/urls.py
@@ -21,7 +21,6 @@ room_router.register(
 _PREFIX = "common/event/<orgslug:organizer>/<slug:event>/interpretation/"
 
 urlpatterns = [
-
     path(
         _PREFIX,
         InterpretationOverview.as_view(),

--- a/interpretation/video_integration.py
+++ b/interpretation/video_integration.py
@@ -19,7 +19,7 @@ def augment_room_config(room, room_config: dict) -> None:
         return
     interpretation = get_interpretation(room)
     stored = interpretation.language_streams if interpretation else []
-    room_config["interpretation_language_streams"] = attendee_language_streams(stored)
+    room_config["interpretation_language_streams"] = attendee_language_streams(stored, event, room)
 
 
 def install_video_integration() -> None:

--- a/interpretation/views_oauth.py
+++ b/interpretation/views_oauth.py
@@ -54,7 +54,7 @@ class VoxbentoOAuthConnectView(EventPermissionRequiredMixin, View):
             "timestamp": time.time(),
         }
 
-        scope_str = "events:read events:write rooms:write booths:read booths:write sessions:manage webhooks:manage"
+        scope_str = "events:read events:write rooms:write booths:read booths:write sessions:manage webhooks:manage listeners:provision"
 
         params = {
             "response_type": "code",

--- a/interpretation/views_oauth.py
+++ b/interpretation/views_oauth.py
@@ -54,7 +54,10 @@ class VoxbentoOAuthConnectView(EventPermissionRequiredMixin, View):
             "timestamp": time.time(),
         }
 
-        scope_str = "events:read events:write rooms:write booths:read booths:write sessions:manage webhooks:manage listeners:provision"
+        scope_str = (
+            "events:read events:write rooms:write booths:read booths:write "
+            "sessions:manage webhooks:manage listeners:provision"
+        )
 
         params = {
             "response_type": "code",


### PR DESCRIPTION
## Description
This PR introduces live captioning support for Eventyay rooms by integrating VoxBento's WebSocket caption streams. It allows attendees to receive real-time captions for both the original floor audio and interpreted language streams.

To support the real-time caption functionality, this PR also hardens the attendee token provisioning and live booth status checking.

- fixes : #108 

## Changes Included
- **Caption WebSocket Integration**:
  - Injects `caption_ws_url` into the `attendee_language_streams` payload for the frontend video player.
  - Generates the appropriate WebSocket URLs (connecting to VoxBento) for both the `floor` and translated language booths.
- **Listener Token Provisioning**:
  - Added the `listeners:provision` OAuth scope to allow Eventyay to request listener tokens for attendees to connect to the streams.
  - Hardened the `listener_token` endpoint to automatically handle `401 Unauthorized` token refreshes for OAuth connections, ensuring attendees can always access caption streams.
  - Excluded attendee-facing endpoints (`listener_token`, `booth_status`) from organizer-level auth requirements.
- **Live Booth Status**:
  - Added a new `@csrf_exempt` `booth_status` endpoint to fetch real-time interpreter/captioner presence for a specific room.
- **Stability Improvements**:
  - `tasks.py` now uses `.update(backend_session_id=...)` when saving the Voxbento Room ID to avoid `RecursionError` caused by post-save signals during background syncs.
  - Only provision streaming URLs for `human` type booths in the sync task.

## How to Test
1. Connect an event to VoxBento using OAuth.
2. Join a video room as an attendee and observe the `attendee_language_streams` payload. It should contain `caption_ws_url` for the streams.
3. Test the `listener_token` API route to ensure a valid token is provided (even if the existing OAuth token has expired and needs refresh).
4. Verify the `booth_status` API route correctly lists available booths for the room.

## Related Issues
Fixes #[Issue Number]

## Summary by Sourcery

Integrate VoxBento live captions and resilient attendee stream access into Eventyay interpretation rooms.

New Features:
- Add real-time VoxBento caption WebSocket URLs for original and translated language streams.
- Provide an attendee-facing booth status endpoint for live interpreter availability.

Bug Fixes:
- Improve listener token retrieval by refreshing expired OAuth credentials and handling temporary VoxBento outages.
- Prevent recursive save failures during room synchronization and exclude non-human booths from streaming URL provisioning.

Enhancements:
- Allow attendee-facing interpretation endpoints to operate without organizer authentication.
- Support OAuth-based listener token provisioning with the required listeners scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Attendees can view live booth presence for their current room.
  - Language stream listings can include caption WebSocket links and supported blank-source streams.
  - Room synchronization preserves the associated interpretation room identifier.

- **Bug Fixes**
  - Improved listener access with OAuth support, automatic token refresh, and clearer unavailable-service responses.
  - Booth listings now support language-code data and a broader range of booth types.
  - Booth status safely returns an empty result when configuration or the external service is unavailable.
  - Fixed room interpretation synchronization when plugin streams are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->