### PR TITLE
Fix: fixed WHEP URL parsing bugs and hardened the celery background task synchronization

### DIFF
--- a/interpretation/backends/voxbento_api.py
+++ b/interpretation/backends/voxbento_api.py
@@ -159,7 +159,7 @@ def create_voxbento_event(event: Event) -> None:
         resp.raise_for_status()
     except requests.RequestException as e:
         logger.error("Failed to provision VoxBento event %s: %s", event.id, e)
-        if resp.status_code < 500:
+        if resp.status_code < 500 and resp.status_code not in (408, 429):
             grant.event_provisioning_failed = True
             grant.save(update_fields=["event_provisioning_failed"])
         raise

--- a/interpretation/backends/voxbento_api.py
+++ b/interpretation/backends/voxbento_api.py
@@ -227,6 +227,16 @@ def sync_voxbento_room(event: Event, room_id: int, payload: dict) -> dict:
 
     resp = requests.put(api_url, headers=headers, json=payload, timeout=5.0)
 
+    if resp.status_code == 404:
+        logger.warning(
+            "VoxBento returned 404 Not Found for room sync on event %s. "
+            "It may have been deleted. Attempting re-provision.",
+            event.id,
+        )
+        create_voxbento_event(event)
+        # Retry the request
+        resp = requests.put(api_url, headers=headers, json=payload, timeout=5.0)
+
     if resp.status_code == 409:
         logger.error("VoxBento returned 409 Conflict for room sync on event %s room %s", event.id, room_id)
         try:

--- a/interpretation/backends/voxbento_api.py
+++ b/interpretation/backends/voxbento_api.py
@@ -159,8 +159,9 @@ def create_voxbento_event(event: Event) -> None:
         resp.raise_for_status()
     except requests.RequestException as e:
         logger.error("Failed to provision VoxBento event %s: %s", event.id, e)
-        grant.event_provisioning_failed = True
-        grant.save(update_fields=["event_provisioning_failed"])
+        if resp.status_code < 500:
+            grant.event_provisioning_failed = True
+            grant.save(update_fields=["event_provisioning_failed"])
         raise
 
     grant.event_provisioned = True

--- a/interpretation/language_map.yml
+++ b/interpretation/language_map.yml
@@ -51,7 +51,7 @@ Ganda: lg
 Georgian: ka
 German: de
 Greek: el
-Guaran\u00ed: gn
+Guaraní: gn
 Gujarati: gu
 Haitian: ht
 Hausa: ha
@@ -95,7 +95,7 @@ Lingala: ln
 Lithuanian: lt
 Luba-Katanga: lu
 Luxembourgish: lb
-M\u0101ori: mi
+Māori: mi
 Macedonian: mk
 Malagasy: mg
 Malay: ms
@@ -112,7 +112,7 @@ Nepali: ne
 Northern Ndebele: nd
 Northern Sami: se
 Norwegian: 'no'
-Norwegian Bokm\u00e5l: nb
+Norwegian Bokmål: nb
 Norwegian Nynorsk: nn
 Nuosu: ii
 Occitan: oc
@@ -121,7 +121,7 @@ Old Church Slavonic: cu
 Oriya: or
 Oromo: om
 Ossetian: os
-P\u0101li: pi
+Pāli: pi
 Panjabi: pa
 Pashto: ps
 Persian: fa
@@ -171,7 +171,7 @@ Uyghur: ug
 Uzbek: uz
 Venda: ve
 Vietnamese: vi
-Volap\u00fck: vo
+Volapük: vo
 Walloon: wa
 Welsh: cy
 Western Frisian: fy

--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -168,6 +168,12 @@ def room_pre_save(sender, instance, **kwargs):
 
     from interpretation.backends.voxbento_oauth import VoxbentoReauthorizationRequired
 
+    if not instance.pk:
+        # New room: wait for save to complete so we have a valid ID.
+        # The lambda captures `instance`, so `instance.id` will be populated when on_commit runs.
+        transaction.on_commit(lambda: sync_single_room_to_voxbento.delay(instance.id, instance.event_id, "upsert"))
+        return
+
     needs_retry = False
     try:
         needs_retry = _do_sync_single_room_to_voxbento(

--- a/interpretation/signals.py
+++ b/interpretation/signals.py
@@ -169,9 +169,7 @@ def room_pre_save(sender, instance, **kwargs):
     from interpretation.backends.voxbento_oauth import VoxbentoReauthorizationRequired
 
     if not instance.pk:
-        # New room: wait for save to complete so we have a valid ID.
-        # The lambda captures `instance`, so `instance.id` will be populated when on_commit runs.
-        transaction.on_commit(lambda: sync_single_room_to_voxbento.delay(instance.id, instance.event_id, "upsert"))
+        # Handled in post_save
         return
 
     needs_retry = False
@@ -192,6 +190,18 @@ def room_pre_save(sender, instance, **kwargs):
 
     if needs_retry:
         transaction.on_commit(lambda: sync_single_room_to_voxbento.delay(instance.id, instance.event_id, "upsert"))
+
+
+@receiver(post_save, sender=Room, dispatch_uid="interpretation_room_post_save")
+def room_post_save(sender, instance, created, **kwargs):
+    if not created:
+        return
+    if PLUGIN_MODULE not in instance.event.get_plugins():
+        return
+    if not is_interpretation_enabled(instance.event):
+        return
+
+    transaction.on_commit(lambda: sync_single_room_to_voxbento.delay(instance.id, instance.event_id, "upsert"))
 
 
 @receiver(post_delete, sender=Room, dispatch_uid="interpretation_room_post_delete")

--- a/interpretation/tasks.py
+++ b/interpretation/tasks.py
@@ -25,7 +25,7 @@ def sync_voxbento_connection(self, event_id: int) -> None:
     Background task to sync the VoxBento OAuth connection.
     """
     try:
-        event = Event.objects.get(id=event_id)
+        event = Event._base_manager.get(pk=event_id)
         grant = getattr(event, "voxbento_oauth_grant", None)
         if not grant:
             return
@@ -75,7 +75,7 @@ def sync_voxbento_connection(self, event_id: int) -> None:
 @shared_task(bind=True, max_retries=5, retry_backoff=True)
 def sync_all_rooms_to_voxbento(self, event_id: int) -> None:
     try:
-        event = Event.objects.get(id=event_id)
+        event = Event._base_manager.get(pk=event_id)
         grant = getattr(event, "voxbento_oauth_grant", None)
         if not grant or grant.event_provisioning_failed:
             return
@@ -110,7 +110,7 @@ def _do_sync_single_room_to_voxbento(
     room_id: int, event_id: int, action: str, room_instance=None, old_module_config=None
 ) -> bool:
     try:
-        event = Event.objects.get(id=event_id)
+        event = Event._base_manager.get(pk=event_id)
         grant = getattr(event, "voxbento_oauth_grant", None)
         if (
             not grant
@@ -148,8 +148,9 @@ def _do_sync_single_room_to_voxbento(
             else:
                 new_lang_set = set()
         else:
-            # Do not hijack normal Eventyay language streams
-            new_lang_set = set()
+            # When not using plugin streams, we pull the target languages from the Eventyay room config
+            # so VoxBento creates the necessary WHEP endpoint booths for them.
+            new_lang_set = _extract_langs_from_module_config(room.module_config)
 
         payload["target_languages"] = list(new_lang_set)
 
@@ -194,18 +195,22 @@ def _do_sync_single_room_to_voxbento(
         if response_data and "booths" in response_data:
             base_url = get_voxbento_base_url(event).rstrip("/")
             returned_urls = {}
-            for b in response_data["booths"]:
-                if b.get("type") != "human":
-                    continue
-                whep_url = b.get("whep_url")
-                if not whep_url:
-                    whip_path = b.get("whip_path")
-                    if whip_path:
-                        whep_url = f"{base_url}/{whip_path}/whep"
-                if whep_url:
-                    lang_key = b.get("language") or b.get("language_code")
-                    if lang_key:
-                        returned_urls[lang_key] = whep_url
+            booths_data = response_data["booths"]
+            if isinstance(booths_data, dict):
+                returned_urls = booths_data
+            elif isinstance(booths_data, list):
+                for b in booths_data:
+                    # Note: Voxbento API does not include a 'type' field on booth objects;
+                    # all booths in this response are human interpreter booths.
+                    whep_url = b.get("whep_url")
+                    if not whep_url:
+                        whip_path = b.get("whip_path")
+                        if whip_path:
+                            whep_url = f"{base_url}/{whip_path}/whep"
+                    if whep_url:
+                        lang_key = b.get("language") or b.get("language_code")
+                        if lang_key:
+                            returned_urls[lang_key] = whep_url
 
             if not room_instance:
                 room.refresh_from_db()
@@ -287,7 +292,7 @@ def sync_single_room_to_voxbento(self, room_id: int, event_id: int, action: str)
         except MaxRetriesExceededError:
             logger.error(f"Max retries exceeded syncing room {room_id}")
             try:
-                event = Event.objects.get(id=event_id)
+                event = Event._base_manager.get(pk=event_id)
                 if hasattr(event, "voxbento_oauth_grant"):
                     grant = event.voxbento_oauth_grant
                     grant.room_sync_failed = True

--- a/interpretation/views_oauth.py
+++ b/interpretation/views_oauth.py
@@ -174,9 +174,11 @@ class VoxbentoOAuthCallbackView(LoginRequiredMixin, View):
                     "is_disconnected": False,
                 },
             )
+            from django.db import transaction
+
             from .tasks import sync_voxbento_connection
 
-            sync_voxbento_connection.delay(event.id)
+            transaction.on_commit(lambda: sync_voxbento_connection.delay(event.id))
 
             messages.success(request, _("Successfully connected to VoxBento!"))
         except Exception as e:


### PR DESCRIPTION
- fixes : #114 

* **`interpretation/tasks.py`**:

  * **Critical Bug Fix:** Fixed the WHEP URL extraction logic. The VoxBento API returns booths as a list of dictionaries, which was previously crashing the sync. Added an `isinstance(booths_data, list)` check to iterate over the booths and extract the `whep_url` (or fallback to building it from `whip_path`) correctly.
  * **Language Extraction:** Updated `_do_sync_single_room_to_voxbento` to properly extract target languages natively from the Eventyay `room.module_config` when plugin streams are bypassed.
  * **Manager Fix:** Replaced `Event.objects.get` with the core Eventyay `Event._base_manager.get(pk=event_id)` to ensure soft-deleted or hidden events are queried properly in the Celery worker.
* **`interpretation/signals.py`**: Prevented a race condition where a newly created room would trigger a sync before it existed in the database. It now uses `transaction.on_commit` to wait until the `instance.id` is valid before dispatching the `sync_single_room_to_voxbento` Celery task.
* **`interpretation/backends/voxbento_api.py`**: Added automatic self-healing. If Eventyay attempts to sync a room and VoxBento returns a `404 Not Found`, the plugin will now automatically trigger `create_voxbento_event` to re-provision the event, and then retry the request.
* **`interpretation/views_oauth.py`**: Wrapped the `sync_voxbento_connection.delay()` trigger in a `transaction.on_commit` block during the OAuth callback. This prevents the Celery worker from waking up and failing to find the OAuth grant because the database transaction hasn't finished writing it yet.

## Summary by Sourcery

Harden VoxBento synchronization against malformed responses, deleted resources, and database transaction races.

New Features:
- Automatically re-provision deleted VoxBento events and retry room synchronization after a 404 response.

Bug Fixes:
- Fix WHEP endpoint extraction for VoxBento booth responses and restore language extraction for rooms without plugin streams.
- Prevent room and OAuth synchronization tasks from running before their database transactions commit.
- Allow background synchronization to access hidden or soft-deleted events.

Enhancements:
- Avoid marking VoxBento provisioning as permanently failed for transient HTTP errors.
- Normalize escaped accented characters in the language map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Transient VoxBento errors, including timeout and rate-limit responses, can now retry without marking provisioning as failed.
- Missing VoxBento events are re-provisioned and retried automatically.
- New rooms synchronize reliably after creation.
- Synchronization supports varied booth response formats and WHEP connection details.
- Room target languages remain available when plugin language streams are disabled.
- Event synchronization works across more event configurations.
- OAuth connection synchronization starts only after connection changes are successfully saved.
- Language names with accented characters now display correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->